### PR TITLE
Docs: pending reserves in totalCashOutWeight is by design (H-4)

### DIFF
--- a/src/JB721TiersHookStore.sol
+++ b/src/JB721TiersHookStore.sol
@@ -455,7 +455,11 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
             // Keep a reference to the stored tier.
             JBStored721Tier memory storedTier = _storedTierOf[hook][i];
 
-            // Add the tier's price multiplied by the number of NFTs minted from the tier.
+            // Add the tier's price multiplied by the number of minted NFTs plus pending reserves.
+            // Pending reserves are included by design — they represent committed obligations that will be
+            // minted to the reserve beneficiary. Including them in the denominator ensures cash-out values
+            // account for the full diluted supply, preventing early cashers from extracting more than their
+            // fair share before reserves are minted.
             weight += storedTier.price
                 * (
                     (storedTier.initialSupply - (storedTier.remainingSupply + numberOfBurnedFor[hook][i]))


### PR DESCRIPTION
## Description

Documents that including pending reserves in `totalCashOutWeight` is intentional. Pending reserves are committed obligations — including them in the denominator ensures cash-out values reflect the full diluted supply, preventing early cashers from extracting more than their fair share before reserves are minted to the beneficiary.

H-4 is by design — not a bug.

## Changes

- Added design rationale comment to `totalCashOutWeight` in `JB721TiersHookStore.sol`