### PR TITLE
fix: validate pricing decimals <= 18 in 721 hook initialization

### DIFF
--- a/src/JB721TiersHook.sol
+++ b/src/JB721TiersHook.sol
@@ -45,6 +45,7 @@ contract JB721TiersHook is JBOwnable, ERC2771Context, JB721Hook, IJB721TiersHook
     error JB721TiersHook_Overspending(uint256 leftoverAmount);
     error JB721TiersHook_MintReserveNftsPaused();
     error JB721TiersHook_TierTransfersPaused();
+    error JB721TiersHook_InvalidPricingDecimals(uint256 decimals);
 
     //*********************************************************************//
     // --------------- public immutable stored properties ---------------- //
@@ -187,6 +188,9 @@ contract JB721TiersHook is JBOwnable, ERC2771Context, JB721Hook, IJB721TiersHook
 
         // Initialize the superclass.
         JB721Hook._initialize(projectId, name, symbol);
+
+        // Validate pricing decimals are within a reasonable range.
+        if (tiersConfig.decimals > 18) revert JB721TiersHook_InvalidPricingDecimals(tiersConfig.decimals);
 
         // Pack pricing context from the `tiersConfig`.
         uint256 packed;

--- a/test/unit/getters_constructor_Unit.t.sol
+++ b/test/unit/getters_constructor_Unit.t.sol
@@ -26,6 +26,8 @@ contract Test_Getters_Constructor_Unit is UnitTestSetup {
     )
         public
     {
+        // Decimals must be <= 18 per validation in initialize.
+        vm.assume(decimals <= 18);
         JBDeploy721TiersHookConfig memory hookConfig = JBDeploy721TiersHookConfig(
             name,
             symbol,


### PR DESCRIPTION
Reject tiersConfig.decimals > 18 to prevent overflow in 10 ** pricingDecimals calculations during tier price comparisons.

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: