### PR TITLE
fix: align interface argument names with implementation

### DIFF
--- a/src/interfaces/IJB721TiersHook.sol
+++ b/src/interfaces/IJB721TiersHook.sol
@@ -45,7 +45,7 @@ interface IJB721TiersHook is IJB721Hook {
     function payCreditsOf(address addr) external view returns (uint256);
     function pricingContext() external view returns (uint256, uint256, IJBPrices);
 
-    function adjustTiers(JB721TierConfig[] calldata tierDataToAdd, uint256[] calldata tierIdsToRemove) external;
+    function adjustTiers(JB721TierConfig[] calldata tiersToAdd, uint256[] calldata tierIdsToRemove) external;
     function initialize(
         uint256 projectId,
         string memory name,
@@ -64,9 +64,9 @@ interface IJB721TiersHook is IJB721Hook {
     function mintPendingReservesFor(uint256 tierId, uint256 count) external;
     function setMetadata(
         string calldata baseUri,
-        string calldata contractMetadataUri,
+        string calldata contractUri,
         IJB721TokenUriResolver tokenUriResolver,
-        uint256 encodedIPFSUriTierId,
+        uint256 encodedIPFSTUriTierId,
         bytes32 encodedIPFSUri
     )
         external;

--- a/src/interfaces/IJB721TiersHookDeployer.sol
+++ b/src/interfaces/IJB721TiersHookDeployer.sol
@@ -13,5 +13,5 @@ interface IJB721TiersHookDeployer {
         bytes32 salt
     )
         external
-        returns (IJB721TiersHook hook);
+        returns (IJB721TiersHook newHook);
 }

--- a/src/interfaces/IJB721TiersHookStore.sol
+++ b/src/interfaces/IJB721TiersHookStore.sol
@@ -37,7 +37,7 @@ interface IJB721TiersHookStore {
         address hook,
         uint256[] calldata categories,
         bool includeResolvedUri,
-        uint256 startingSortIndex,
+        uint256 startingId,
         uint256 size
     )
         external
@@ -51,9 +51,9 @@ interface IJB721TiersHookStore {
     function votingUnitsOf(address hook, address account) external view returns (uint256 units);
 
     function cleanTiers(address hook) external;
-    function recordAddTiers(JB721TierConfig[] calldata tierData) external returns (uint256[] memory tierIds);
+    function recordAddTiers(JB721TierConfig[] calldata tiersToAdd) external returns (uint256[] memory tierIds);
     function recordBurn(uint256[] calldata tokenIds) external;
-    function recordFlags(JB721TiersHookFlags calldata flag) external;
+    function recordFlags(JB721TiersHookFlags calldata flags) external;
     function recordMint(
         uint256 amount,
         uint16[] calldata tierIds,


### PR DESCRIPTION
Fixes argument name mismatches in IJB721TiersHook, IJB721TiersHookStore, and IJB721TiersHookDeployer to match their implementations.

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: