### PR TITLE
Append V6 to deploy salts

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -22,10 +22,10 @@ contract DeployScript is Script, Sphinx {
     address private TRUSTED_FORWARDER;
 
     /// @notice the salts that are used to deploy the contracts.
-    bytes32 HOOK_SALT = "JB721TiersHook_";
-    bytes32 HOOK_DEPLOYER_SALT = "JB721TiersHookDeployer_";
-    bytes32 HOOK_STORE_SALT = "JB721TiersHookStore_";
-    bytes32 PROJECT_DEPLOYER_SALT = "JB721TiersHookProjectDeployer_";
+    bytes32 HOOK_SALT = "JB721TiersHookV6_";
+    bytes32 HOOK_DEPLOYER_SALT = "JB721TiersHookDeployerV6_";
+    bytes32 HOOK_STORE_SALT = "JB721TiersHookStoreV6_";
+    bytes32 PROJECT_DEPLOYER_SALT = "JB721TiersHookProjectDeployerV6";
 
     function configureSphinx() public override {
         // TODO: Update to contain JB Emergency Developers

--- a/script/Deploy5_1.s.sol
+++ b/script/Deploy5_1.s.sol
@@ -23,10 +23,10 @@ contract DeployScript is Script, Sphinx {
     address private TRUSTED_FORWARDER;
 
     /// @notice the salts that are used to deploy the contracts.
-    bytes32 HOOK_SALT = "JB721TiersHook_";
-    bytes32 HOOK_DEPLOYER_SALT = "JB721TiersHookDeployer_";
-    bytes32 HOOK_STORE_SALT = "JB721TiersHookStore_";
-    bytes32 PROJECT_DEPLOYER_SALT = "JB721TiersHookProjectDeployer_";
+    bytes32 HOOK_SALT = "JB721TiersHookV6_";
+    bytes32 HOOK_DEPLOYER_SALT = "JB721TiersHookDeployerV6_";
+    bytes32 HOOK_STORE_SALT = "JB721TiersHookStoreV6_";
+    bytes32 PROJECT_DEPLOYER_SALT = "JB721TiersHookProjectDeployerV6";
 
     function configureSphinx() public override {
         sphinxConfig.projectName = "nana-721-hook-v5";


### PR DESCRIPTION
## Summary
- Updated `HOOK_SALT`, `HOOK_DEPLOYER_SALT`, `HOOK_STORE_SALT`, `PROJECT_DEPLOYER_SALT` with V6 suffix in both `Deploy.s.sol` and `Deploy5_1.s.sol`

Ensures all V6 contracts deploy to different deterministic addresses than V5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)