### PR TITLE
chore: standardize slither CI, convert positional args to named params

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    env:
+      NODE_ENV: production
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,7 +21,7 @@ jobs:
         with:
           node-version: latest
       - name: Install npm dependencies
-        run: npm ci
+        run: npm ci --production
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Run slither

--- a/src/JB721TiersHook.sol
+++ b/src/JB721TiersHook.sol
@@ -155,7 +155,7 @@ contract JB721TiersHook is JBOwnable, ERC2771Context, JB721Hook, IJB721TiersHook
     /// @param owner The address to check the balance of.
     /// @return balance The number of NFTs the address owns across this hook's tiers.
     function balanceOf(address owner) public view override returns (uint256 balance) {
-        return STORE.balanceOf(address(this), owner);
+        return STORE.balanceOf({hook: address(this), owner: owner});
     }
 
     /// @notice Initializes a cloned copy of the original `JB721Hook` contract.
@@ -188,7 +188,7 @@ contract JB721TiersHook is JBOwnable, ERC2771Context, JB721Hook, IJB721TiersHook
         if (projectId == 0) revert JB721TiersHook_NoProjectId();
 
         // Initialize the superclass.
-        JB721Hook._initialize(projectId, name, symbol);
+        JB721Hook._initialize({projectId: projectId, name: name, symbol: symbol});
 
         // Validate pricing decimals are within a reasonable range.
         if (tiersConfig.decimals > 18) revert JB721TiersHook_InvalidPricingDecimals(tiersConfig.decimals);
@@ -245,7 +245,7 @@ contract JB721TiersHook is JBOwnable, ERC2771Context, JB721Hook, IJB721TiersHook
         override
         returns (uint256)
     {
-        return STORE.cashOutWeightOf(address(this), tokenIds);
+        return STORE.cashOutWeightOf({hook: address(this), tokenIds: tokenIds});
     }
 
     /// @notice Indicates if this contract adheres to the specified interface.
@@ -266,10 +266,13 @@ contract JB721TiersHook is JBOwnable, ERC2771Context, JB721Hook, IJB721TiersHook
         IJB721TokenUriResolver resolver = STORE.tokenUriResolverOf(address(this));
 
         // If a `tokenUriResolver` is set, use it to resolve the token URI.
-        if (address(resolver) != address(0)) return resolver.tokenUriOf(address(this), tokenId);
+        if (address(resolver) != address(0)) return resolver.tokenUriOf({nft: address(this), tokenId: tokenId});
 
         // Otherwise, return the token URI corresponding with the NFT's tier.
-        return JBIpfsDecoder.decode(baseURI, STORE.encodedTierIPFSUriOf(address(this), tokenId));
+        return JBIpfsDecoder.decode({
+            baseUri: baseURI,
+            hexString: STORE.encodedTierIPFSUriOf({hook: address(this), tokenId: tokenId})
+        });
     }
 
     /// @notice The combined cash out weight of all outstanding NFTs.
@@ -401,7 +404,7 @@ contract JB721TiersHook is JBOwnable, ERC2771Context, JB721Hook, IJB721TiersHook
             JB721TiersMintReservesConfig memory params = reserveMintConfigs[i];
 
             // Mint pending reserved NFTs from the tier.
-            mintPendingReservesFor(params.tierId, params.count);
+            mintPendingReservesFor({tierId: params.tierId, count: params.count});
         }
     }
 
@@ -418,7 +421,7 @@ contract JB721TiersHook is JBOwnable, ERC2771Context, JB721Hook, IJB721TiersHook
             projectId: PROJECT_ID,
             permissionId: JBPermissionIds.SET_721_DISCOUNT_PERCENT
         });
-        _setDiscountPercentOf(tierId, discountPercent);
+        _setDiscountPercentOf({tierId: tierId, discountPercent: discountPercent});
     }
 
     /// @notice Allows the collection's owner to set the discount percent for multiple tiers.
@@ -435,7 +438,7 @@ contract JB721TiersHook is JBOwnable, ERC2771Context, JB721Hook, IJB721TiersHook
             // Set the config being iterated on.
             JB721TiersSetDiscountPercentConfig memory config = configs[i];
 
-            _setDiscountPercentOf(config.tierId, config.discountPercent);
+            _setDiscountPercentOf({tierId: config.tierId, discountPercent: config.discountPercent});
         }
     }
 
@@ -479,7 +482,7 @@ contract JB721TiersHook is JBOwnable, ERC2771Context, JB721Hook, IJB721TiersHook
             emit SetEncodedIPFSUri({tierId: encodedIPFSUriTierId, encodedUri: encodedIPFSUri, caller: _msgSender()});
 
             // Store the new encoded IPFS URI.
-            STORE.recordSetEncodedIPFSUriOf(encodedIPFSUriTierId, encodedIPFSUri);
+            STORE.recordSetEncodedIPFSUriOf({tierId: encodedIPFSUriTierId, encodedIPFSUri: encodedIPFSUri});
         }
     }
 
@@ -503,11 +506,11 @@ contract JB721TiersHook is JBOwnable, ERC2771Context, JB721Hook, IJB721TiersHook
 
         // Record the reserved mint for the tier.
         // slither-disable-next-line reentrancy-events,calls-loop
-        uint256[] memory tokenIds = STORE.recordMintReservesFor(tierId, count);
+        uint256[] memory tokenIds = STORE.recordMintReservesFor({tierId: tierId, count: count});
 
         // Keep a reference to the beneficiary.
         // slither-disable-next-line calls-loop
-        address reserveBeneficiary = STORE.reserveBeneficiaryOf(address(this), tierId);
+        address reserveBeneficiary = STORE.reserveBeneficiaryOf({hook: address(this), tierId: tierId});
 
         for (uint256 i; i < count; i++) {
             // Set the token ID.
@@ -641,7 +644,10 @@ contract JB721TiersHook is JBOwnable, ERC2771Context, JB721Hook, IJB721TiersHook
 
         // Resolve the metadata.
         (bool found, bytes memory metadata) =
-            JBMetadataResolver.getDataFor(JBMetadataResolver.getId("pay", METADATA_ID_TARGET), context.payerMetadata);
+            JBMetadataResolver.getDataFor({
+                id: JBMetadataResolver.getId({purpose: "pay", target: METADATA_ID_TARGET}),
+                metadata: context.payerMetadata
+            });
 
         if (found) {
             // Keep a reference to the IDs of the tier be to minted.
@@ -762,6 +768,6 @@ contract JB721TiersHook is JBOwnable, ERC2771Context, JB721Hook, IJB721TiersHook
 
         // Record the transfer.
         // slither-disable-next-line reentrency-events,calls-loop
-        STORE.recordTransferForTier(tier.id, from, to);
+        STORE.recordTransferForTier({tierId: tier.id, from: from, to: to});
     }
 }

--- a/src/JB721TiersHookStore.sol
+++ b/src/JB721TiersHookStore.sol
@@ -175,7 +175,7 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
     /// @param tierId The ID of the tier to get the number of pending reserves for.
     /// @return The number of pending reserved NFTs.
     function numberOfPendingReservesFor(address hook, uint256 tierId) external view override returns (uint256) {
-        return _numberOfPendingReservesFor(hook, tierId, _storedTierOf[hook][tierId]);
+        return _numberOfPendingReservesFor({hook: hook, tierId: tierId, storedTier: _storedTierOf[hook][tierId]});
     }
 
     /// @notice Get the tier of the 721 with the provided token ID in the provided 721 contract.
@@ -196,7 +196,7 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
     {
         // Get a reference to the tier's ID.
         uint256 tierId = tierIdOfToken(tokenId);
-        return _getTierFrom(hook, tierId, _storedTierOf[hook][tierId], includeResolvedUri);
+        return _getTierFrom({hook: hook, tierId: tierId, storedTier: _storedTierOf[hook][tierId], includeResolvedUri: includeResolvedUri});
     }
 
     /// @notice Returns the number of voting units an addresses has within the specified tier of the specified 721
@@ -282,11 +282,11 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
             // Get a reference to the ID of the tier being iterated upon, starting with the first tier ID if no starting
             // ID was specified.
             uint256 currentSortedTierId =
-                startingId != 0 ? startingId : _firstSortedTierIdOf(hook, categories.length == 0 ? 0 : categories[i]);
+                startingId != 0 ? startingId : _firstSortedTierIdOf({hook: hook, category: categories.length == 0 ? 0 : categories[i]});
 
             // Add the tiers from the category being iterated upon.
             while (currentSortedTierId != 0 && numberOfIncludedTiers < size) {
-                if (!_isTierRemovedWithRefresh(hook, currentSortedTierId, bitmapWord)) {
+                if (!_isTierRemovedWithRefresh({hook: hook, tierId: currentSortedTierId, bitmapWord: bitmapWord})) {
                     storedTier = _storedTierOf[hook][currentSortedTierId];
 
                     // If categories were provided and the current tier's category is greater than category being added,
@@ -298,11 +298,11 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
                     else if (categories.length == 0 || storedTier.category == categories[i]) {
                         // Add the tier to the array being returned.
                         tiers[numberOfIncludedTiers++] =
-                            _getTierFrom(hook, currentSortedTierId, storedTier, includeResolvedUri);
+                            _getTierFrom({hook: hook, tierId: currentSortedTierId, storedTier: storedTier, includeResolvedUri: includeResolvedUri});
                     }
                 }
                 // Set the next sorted tier ID.
-                currentSortedTierId = _nextSortedTierIdOf(hook, currentSortedTierId, lastTierId);
+                currentSortedTierId = _nextSortedTierIdOf({hook: hook, id: currentSortedTierId, max: lastTierId});
             }
 
             unchecked {
@@ -385,7 +385,7 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
         override
         returns (JB721Tier memory)
     {
-        return _getTierFrom(hook, id, _storedTierOf[hook][id], includeResolvedUri);
+        return _getTierFrom({hook: hook, tierId: id, storedTier: _storedTierOf[hook][id], includeResolvedUri: includeResolvedUri});
     }
 
     /// @notice Get the number of NFTs that the specified address has from the specified 721 contract (across all
@@ -467,7 +467,7 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
             weight += storedTier.price
                 * (
                     (storedTier.initialSupply - (storedTier.remainingSupply + numberOfBurnedFor[hook][i]))
-                        + _numberOfPendingReservesFor(hook, i, storedTier)
+                        + _numberOfPendingReservesFor({hook: hook, tierId: i, storedTier: storedTier})
                 );
         }
     }
@@ -514,7 +514,7 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
         returns (JB721Tier memory)
     {
         // Get a reference to the reserve beneficiary.
-        address reserveBeneficiary = reserveBeneficiaryOf(hook, tierId);
+        address reserveBeneficiary = reserveBeneficiaryOf({hook: hook, tierId: tierId});
 
         (
             bool allowOwnerMint,
@@ -543,7 +543,7 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
             cannotIncreaseDiscountPercent: cannotIncreaseDiscountPercent,
             resolvedUri: !includeResolvedUri || tokenUriResolverOf[hook] == IJB721TokenUriResolver(address(0))
                 ? ""
-                : tokenUriResolverOf[hook].tokenUriOf(hook, _generateTokenId(tierId, 0))
+                : tokenUriResolverOf[hook].tokenUriOf({nft: hook, tokenId: _generateTokenId({tierId: tierId, tokenNumber: 0})})
         });
     }
 
@@ -624,7 +624,7 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
         // No pending reserves if no mints, no reserve frequency, or no reserve beneficiary.
         if (
             storedTier.reserveFrequency == 0 || initialSupply == storedTier.remainingSupply
-                || reserveBeneficiaryOf(hook, tierId) == address(0)
+                || reserveBeneficiaryOf({hook: hook, tierId: tierId}) == address(0)
         ) return 0;
 
         // The number of reserve NFTs which have already been minted from the tier.
@@ -719,7 +719,7 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
         uint256 lastSortedTierId = _lastSortedTierIdOf(hook);
 
         // Get a reference to the tier ID being iterated on, starting with the starting tier ID.
-        uint256 currentSortedTierId = _firstSortedTierIdOf(hook, 0);
+        uint256 currentSortedTierId = _firstSortedTierIdOf({hook: hook, category: 0});
 
         // Keep track of the previous non-removed tier ID.
         uint256 previousSortedTierId;
@@ -730,7 +730,7 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
         // Make the sorted array.
         while (currentSortedTierId != 0) {
             // If the current tier ID being iterated on isn't an increment of the previous one,
-            if (!_isTierRemovedWithRefresh(hook, currentSortedTierId, bitmapWord)) {
+            if (!_isTierRemovedWithRefresh({hook: hook, tierId: currentSortedTierId, bitmapWord: bitmapWord})) {
                 // Update its `_tierIdAfter` if needed.
                 if (currentSortedTierId != previousSortedTierId + 1) {
                     if (_tierIdAfter[hook][previousSortedTierId] != currentSortedTierId) {
@@ -747,7 +747,7 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
                 previousSortedTierId = currentSortedTierId;
             }
             // Iterate by updating the current sorted tier ID to the next sorted tier ID.
-            currentSortedTierId = _nextSortedTierIdOf(hook, currentSortedTierId, lastSortedTierId);
+            currentSortedTierId = _nextSortedTierIdOf({hook: hook, id: currentSortedTierId, max: lastSortedTierId});
         }
 
         emit CleanTiers({hook: hook, caller: msg.sender});
@@ -777,7 +777,7 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
 
         // Keep a reference to the first sorted tier ID, to use when sorting new tiers if needed.
         // There's no need for sorting if there are no current tiers.
-        uint256 startSortedTierId = currentMaxTierIdOf == 0 ? 0 : _firstSortedTierIdOf(msg.sender, 0);
+        uint256 startSortedTierId = currentMaxTierIdOf == 0 ? 0 : _firstSortedTierIdOf({hook: msg.sender, category: 0});
 
         // Keep track of the previous tier's ID while iterating.
         uint256 previousTierId;
@@ -853,13 +853,13 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
                 reserveFrequency: uint16(tierToAdd.reserveFrequency),
                 category: uint24(tierToAdd.category),
                 discountPercent: uint8(tierToAdd.discountPercent),
-                packedBools: _packBools(
-                    tierToAdd.allowOwnerMint,
-                    tierToAdd.transfersPausable,
-                    tierToAdd.useVotingUnits,
-                    tierToAdd.cannotBeRemoved,
-                    tierToAdd.cannotIncreaseDiscountPercent
-                )
+                packedBools: _packBools({
+                    allowOwnerMint: tierToAdd.allowOwnerMint,
+                    transfersPausable: tierToAdd.transfersPausable,
+                    useVotingUnits: tierToAdd.useVotingUnits,
+                    cannotBeRemoved: tierToAdd.cannotBeRemoved,
+                    cannotIncreaseDiscountPercent: tierToAdd.cannotIncreaseDiscountPercent
+                })
             });
 
             // If this is the first tier in a new category, store it as the first tier in that category.
@@ -895,7 +895,7 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
                 // Make sure the tier is sorted correctly.
                 while (currentSortedTierId != 0) {
                     // Set the next tier ID.
-                    nextTierId = _nextSortedTierIdOf(msg.sender, currentSortedTierId, currentLastSortedTierId);
+                    nextTierId = _nextSortedTierIdOf({hook: msg.sender, id: currentSortedTierId, max: currentLastSortedTierId});
 
                     // If the category is less than or equal to the sorted tier being iterated on,
                     // AND the tier being iterated on isn't among those being added, store the order.
@@ -1025,7 +1025,7 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
             uint256 tierId = tierIds[i];
 
             // Make sure the tier hasn't been removed.
-            if (_isTierRemovedWithRefresh(msg.sender, tierId, bitmapWord)) {
+            if (_isTierRemovedWithRefresh({hook: msg.sender, tierId: tierId, bitmapWord: bitmapWord})) {
                 revert JB721TiersHookStore_TierRemoved(tierId);
             }
 
@@ -1059,12 +1059,12 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
             // sees the post-mint state (this non-reserve mint may increase pending reserves).
             unchecked {
                 // Keep a reference to its token ID.
-                tokenIds[i] = _generateTokenId(tierId, storedTier.initialSupply - --storedTier.remainingSupply);
+                tokenIds[i] = _generateTokenId({tierId: tierId, tokenNumber: storedTier.initialSupply - --storedTier.remainingSupply});
                 leftoverAmount = leftoverAmount - price;
             }
 
             // Make sure there are still enough NFTs remaining to satisfy pending reserves.
-            if (storedTier.remainingSupply < _numberOfPendingReservesFor(msg.sender, tierId, storedTier)) {
+            if (storedTier.remainingSupply < _numberOfPendingReservesFor({hook: msg.sender, tierId: tierId, storedTier: storedTier})) {
                 revert JB721TiersHookStore_InsufficientSupplyRemaining(tierId);
             }
         }
@@ -1087,7 +1087,7 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
 
         // Get a reference to the number of pending reserve NFTs for the tier.
         // "Pending" means that the NFTs have been reserved, but have not been minted yet.
-        uint256 numberOfPendingReserves = _numberOfPendingReservesFor(msg.sender, tierId, storedTier);
+        uint256 numberOfPendingReserves = _numberOfPendingReservesFor({hook: msg.sender, tierId: tierId, storedTier: storedTier});
 
         // Can't mint more than the number of pending reserves.
         if (count > numberOfPendingReserves) {
@@ -1102,7 +1102,7 @@ contract JB721TiersHookStore is IJB721TiersHookStore {
 
         for (uint256 i; i < count; i++) {
             // Generate the NFTs.
-            tokenIds[i] = _generateTokenId(tierId, storedTier.initialSupply - --storedTier.remainingSupply);
+            tokenIds[i] = _generateTokenId({tierId: tierId, tokenNumber: storedTier.initialSupply - --storedTier.remainingSupply});
         }
     }
 

--- a/src/abstract/JB721Hook.sol
+++ b/src/abstract/JB721Hook.sol
@@ -118,11 +118,14 @@ abstract contract JB721Hook is ERC721, IJB721Hook {
 
         // Fetch the cash out hook metadata using the corresponding metadata ID.
         (bool metadataExists, bytes memory metadata) =
-            JBMetadataResolver.getDataFor(JBMetadataResolver.getId("cashOut", METADATA_ID_TARGET), context.metadata);
+            JBMetadataResolver.getDataFor({
+                id: JBMetadataResolver.getId({purpose: "cashOut", target: METADATA_ID_TARGET}),
+                metadata: context.metadata
+            });
 
         // Use this contract as the only cash out hook.
         hookSpecifications = new JBCashOutHookSpecification[](1);
-        hookSpecifications[0] = JBCashOutHookSpecification(this, 0, bytes(""));
+        hookSpecifications[0] = JBCashOutHookSpecification({hook: this, amount: 0, metadata: bytes("")});
 
         uint256[] memory decodedTokenIds;
 
@@ -130,7 +133,7 @@ abstract contract JB721Hook is ERC721, IJB721Hook {
         if (metadataExists) decodedTokenIds = abi.decode(metadata, (uint256[]));
 
         // Use the cash out weight of the provided 721s.
-        cashOutCount = cashOutWeightOf(decodedTokenIds, context);
+        cashOutCount = cashOutWeightOf({tokenIds: decodedTokenIds, context: context});
 
         // Use the total cash out weight of the 721s.
         totalSupply = totalCashOutWeight(context);
@@ -204,7 +207,7 @@ abstract contract JB721Hook is ERC721, IJB721Hook {
         // Make sure the caller is a terminal of the project, and that the call is being made on behalf of an
         // interaction with the correct project.
         if (
-            msg.value != 0 || !DIRECTORY.isTerminalOf(projectId, IJBTerminal(msg.sender))
+            msg.value != 0 || !DIRECTORY.isTerminalOf({projectId: projectId, terminal: IJBTerminal(msg.sender)})
                 || context.projectId != projectId
         ) revert JB721Hook_InvalidPay();
 
@@ -229,14 +232,15 @@ abstract contract JB721Hook is ERC721, IJB721Hook {
         // Make sure the caller is a terminal of the project, and that the call is being made on behalf of an
         // interaction with the correct project.
         if (
-            msg.value != 0 || !DIRECTORY.isTerminalOf(projectId, IJBTerminal(msg.sender))
+            msg.value != 0 || !DIRECTORY.isTerminalOf({projectId: projectId, terminal: IJBTerminal(msg.sender)})
                 || context.projectId != projectId
         ) revert JB721Hook_InvalidCashOut();
 
         // Fetch the cash out hook metadata using the corresponding metadata ID.
-        (bool metadataExists, bytes memory metadata) = JBMetadataResolver.getDataFor(
-            JBMetadataResolver.getId("cashOut", METADATA_ID_TARGET), context.cashOutMetadata
-        );
+        (bool metadataExists, bytes memory metadata) = JBMetadataResolver.getDataFor({
+            id: JBMetadataResolver.getId({purpose: "cashOut", target: METADATA_ID_TARGET}),
+            metadata: context.cashOutMetadata
+        });
 
         uint256[] memory decodedTokenIds;
 
@@ -268,7 +272,7 @@ abstract contract JB721Hook is ERC721, IJB721Hook {
     /// @param name The name of the NFT collection.
     /// @param symbol The symbol representing the NFT collection.
     function _initialize(uint256 projectId, string memory name, string memory symbol) internal {
-        ERC721._initialize(name, symbol);
+        ERC721._initialize({name_: name, symbol_: symbol});
         PROJECT_ID = projectId;
     }
 


### PR DESCRIPTION
## Summary
- Standardize slither workflow (add `NODE_ENV: production`, `npm ci --production`)
- Convert ~39 positional function calls to named parameters across JB721TiersHook, JB721Hook, JB721TiersHookStore

## Test plan
- [x] `forge build` passes (src only; pre-existing v6 package issue in tests)
- [ ] `forge test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)